### PR TITLE
Add z'5 as an artist

### DIFF
--- a/DISC 4 - First Anniversary (2023-12-19 - 2024-06-26)/112. Neru - 病名は愛だった (The Disease Called Love) (Duet.v1) (Neuro & Evil).hjson
+++ b/DISC 4 - First Anniversary (2023-12-19 - 2024-06-26)/112. Neru - 病名は愛だった (The Disease Called Love) (Duet.v1) (Neuro & Evil).hjson
@@ -1,7 +1,7 @@
 {
   Date: 2024-05-01
   Title: 病名は愛だった (The Disease Called Love)
-  Artist: Neru
+  Artist: Neru, z’5
   CoverArtist: Neuro & Evil
   Version: 1
   Discnumber: 4


### PR DESCRIPTION
Supposedly there is a Neru only version, but as it is less common I was able to find it only with z’5. Reason then leads me to believe that Pb also used the most common version. The artist should therefore be “Neru, z’5”.