### PR TITLE
Fix versioning for "Baka Mitai"

### DIFF
--- a/DISC 1 - Humble Beginnings (2023-01-03 - 2023-05-17)/018. Mitsuharu Fukuyama, Ryosuke Horii - ばかみたい (Baka Mitai) (Neuro.v1).hjson
+++ b/DISC 1 - Humble Beginnings (2023-01-03 - 2023-05-17)/018. Mitsuharu Fukuyama, Ryosuke Horii - ばかみたい (Baka Mitai) (Neuro.v1).hjson
@@ -2,7 +2,9 @@
   Date: 2023-02-07
   Title: Baka Mitai
   TitleOG: ばかみたい
-  Artist: Mitsuharu Fukuyama, Ryosuke Horii
+  Identify: 【Full Spec Edition】
+  Artist: Taiga Saejima (Rikiya Koyama), Mitsuharu Fukuyama, Ryosuke Horii
+  ArtistOG: 	冴島大河 (小山力也), 福山光晴, 堀井亮佑
   CoverArtist: Neuro
   Version: 1
   Discnumber: 1

--- a/DISC 2 - A Small Upgrade (2023-05-27 - 2023-06-08)/021. Mitsuharu Fukuyama, Ryosuke Horii - ばかみたい (Baka Mitai) (Neuro.v2).hjson
+++ b/DISC 2 - A Small Upgrade (2023-05-27 - 2023-06-08)/021. Mitsuharu Fukuyama, Ryosuke Horii - ばかみたい (Baka Mitai) (Neuro.v2).hjson
@@ -2,7 +2,9 @@
   Date: 2023-05-31
   Title: Baka Mitai
   TitleOG: ばかみたい
-  Artist: Mitsuharu Fukuyama, Ryosuke Horii
+  Identify: 【Taxi Driver Edition】
+  Artist: Kazuma Kiryu (Takaya Kuroda), Mitsuharu Fukuyama, Ryosuke Horii
+  ArtistOG: 桐生一馬 (黒田崇矢), 福山光晴, 堀井亮佑
   CoverArtist: Neuro
   Version: 2
   Discnumber: 2

--- a/DISC 3 - The Gold Standard (2023-06-21 - 2023-12-06)/140. Mitsuharu Fukuyama, Ryosuke Horii - ばかみたい (Baka Mitai) (Neuro.v3).hjson
+++ b/DISC 3 - The Gold Standard (2023-06-21 - 2023-12-06)/140. Mitsuharu Fukuyama, Ryosuke Horii - ばかみたい (Baka Mitai) (Neuro.v3).hjson
@@ -2,7 +2,9 @@
   Date: 2023-09-03
   Title: Baka Mitai
   TitleOG: ばかみたい
-  Artist: Mitsuharu Fukuyama, Ryosuke Horii
+  Identify: 【Taxi Driver Edition】
+  Artist: Kazuma Kiryu (Takaya Kuroda), Mitsuharu Fukuyama, Ryosuke Horii
+  ArtistOG: 桐生一馬 (黒田崇矢), 福山光晴, 堀井亮佑
   CoverArtist: Neuro
   Version: 3
   Discnumber: 3

--- a/DISC 8 - Third Anniversary (2025-12-19 - Present)/144. Mitsuharu Fukuyama - Baka Mitai (Neuro.v3).hjson
+++ b/DISC 8 - Third Anniversary (2025-12-19 - Present)/144. Mitsuharu Fukuyama - Baka Mitai (Neuro.v3).hjson
@@ -1,9 +1,12 @@
 {
   Date: 2026-04-01
   Title: Baka Mitai
-  Artist: Mitsuharu Fukuyama
+  TitleOG: ばかみたい
+  Identify: 【Full Spec Edition】
+  Artist: Taiga Saejima (Rikiya Koyama), Mitsuharu Fukuyama, Ryosuke Horii
+  ArtistOG: 冴島大河 (小山力也), 福山光晴, 堀井亮佑
   CoverArtist: Neuro
-  Version: 3
+  Version: 3.2
   Discnumber: 8
   Track: 144
   xxHash: cfafacf416724e34


### PR DESCRIPTION
- Change latest Version for 3.2
- Add original singers as Artists
- Add kanji

based on @hallidayasr's comment and research:

"""
Thank you! I can identify V1 Baka Mitai as based on "ばかみたい【Full Spec Edition】 · Taiga Saejima(Rikiya Koyama) · 堀井亮佑 · 福山光晴 · 福山光晴" while both V2 and the previous V3 covers are based on "ばかみたい【Taxi Driver Edition】 · Kazuma Kiryu(Takaya Kuroda) · SEGA GAME MUSIC · SEGA SOUND TEAM · 堀井亮佑 · 福山光晴 · 福山光晴"; the latest V3 cover is based on  "ばかみたい【Full Spec Edition】 · Taiga Saejima(Rikiya Koyama) · 堀井亮佑 · 福山光晴 · 福山光晴" (so Neuro went back to her roots) """