### PR TITLE
fix: correct artist for Disc 7 track 82 Bitter Sweet Symphony (Busted → The Verve)

### DIFF
--- a/DISC 7 - Background Running Process (2025-05-28 - 2025-11-26)/082. The Verve - Bitter Sweet Symphony (Evil.v1).hjson
+++ b/DISC 7 - Background Running Process (2025-05-28 - 2025-11-26)/082. The Verve - Bitter Sweet Symphony (Evil.v1).hjson
@@ -1,7 +1,7 @@
 {
   Date: 2025-07-23
   Title: Bitter Sweet Symphony
-  Artist: Busted
+  Artist: The Verve
   CoverArtist: Evil
   Version: 1
   Discnumber: 7


### PR DESCRIPTION
In Disc 7 track 082, "Bitter Sweet Symphony" is attributed to **Busted** — but the song is by **The Verve**. Busted covered it, but the version sung in the karaoke stream is the original.

https://musicbrainz.org/work/b148c2ee-9575-3ef4-9b32-36cb7f59c2e9

This PR renames the file and updates the `Artist` field to `The Verve`.

Closes #126