### PR TITLE
fix: add Coldplay as co-artist for Disc 7 track 98 Something Just Like This

### DIFF
--- a/DISC 7 - Background Running Process (2025-05-28 - 2025-11-26)/098. The Chainsmokers, Coldplay - Something Just Like This (Neuro.v3).hjson
+++ b/DISC 7 - Background Running Process (2025-05-28 - 2025-11-26)/098. The Chainsmokers, Coldplay - Something Just Like This (Neuro.v3).hjson
@@ -1,7 +1,7 @@
 {
   Date: 2025-08-19
   Title: Something Just Like This
-  Artist: The Chainsmokers
+  Artist: The Chainsmokers, Coldplay
   CoverArtist: Neuro
   Version: 3
   Discnumber: 7


### PR DESCRIPTION
In Disc 7 track 098, "Something Just Like This" is listed as a solo **The Chainsmokers** track — but it's a collaboration with **Coldplay**.

This PR renames the file and updates the `Artist` field to `The Chainsmokers, Coldplay`.