### PR TITLE
fix: correct title for Disc 7 track 132 from "Demon" to "Demons"

### DIFF
--- a/DISC 7 - Background Running Process (2025-05-28 - 2025-11-26)/132. Imagine Dragons - Demons (Evil.v1).hjson
+++ b/DISC 7 - Background Running Process (2025-05-28 - 2025-11-26)/132. Imagine Dragons - Demons (Evil.v1).hjson
@@ -1,6 +1,6 @@
 {
   Date: 2025-09-03
-  Title: Demon
+  Title: Demons
   Artist: Imagine Dragons
   CoverArtist: Evil
   Version: 1


### PR DESCRIPTION
In Disc 7 track 132, the Imagine Dragons song is titled **"Demon"** — the correct title is **"Demons"** (with an 's').

https://musicbrainz.org/work/42462391-3cdb-4af6-8a6c-386021ea6d6c

This PR renames the file and updates the `Title` field accordingly.

Closes #129 