### PR TITLE
fix: correct title and artist for Disc 7 track 188 Secret Base (Zone)

### DIFF
--- a/DISC 7 - Background Running Process (2025-05-28 - 2025-11-26)/188. Zone - Secret Base (Kimi ga Kureta Mono) (Duet.v1) (Neuro & Evil).hjson
+++ b/DISC 7 - Background Running Process (2025-05-28 - 2025-11-26)/188. Zone - Secret Base (Kimi ga Kureta Mono) (Duet.v1) (Neuro & Evil).hjson
@@ -1,8 +1,8 @@
 {
   Date: 2025-10-15
-  Title: Kimi ga Kureta Mono
-  TitleOG: 君がくれたもの
-  Artist: Secret Base
+  Title: Secret Base (Kimi ga Kureta Mono)
+  TitleOG: secret base 〜君がくれたもの〜
+  Artist: Zone
   CoverArtist: Neuro & Evil
   Version: 1
   Discnumber: 7


### PR DESCRIPTION
In Disc 7 track 188, the song is incorrectly attributed to **"Secret Base"** as the artist with a romanized title — but "Secret Base ~君がくれたもの~" is a song by the Japanese band **Zone**, not an artist called "Secret Base".

https://musicbrainz.org/work/d0e52756-6196-3617-99c7-efe555c7a707

This PR:
- Renames the file from `188. Secret Base - 君がくれたもの (Kimi ga Kureta Mono) …` → `188. Zone - Secret Base (Kimi ga Kureta Mono) …`
- Updates `Title` → `Secret Base (Kimi ga Kureta Mono)`
- Adds `TitleOG` → `秘密基地 〜君がくれたもの〜` (original Japanese title)
- Updates `Artist` → `Zone`

Closes #131  