### PR TITLE
fix: correct Artist field for Disc 5 track 115 Caramelldansen (Caramell → Caramella Girls)

### DIFF
--- a/DISC 5 - Non-Stop Innovation (2024-07-10 - 2024-11-17)/115. Caramella Girls - Caramelldansen (Neuro.v3).hjson
+++ b/DISC 5 - Non-Stop Innovation (2024-07-10 - 2024-11-17)/115. Caramella Girls - Caramelldansen (Neuro.v3).hjson
@@ -1,7 +1,7 @@
 {
   Date: 2024-10-06
   Title: Caramelldansen
-  Artist: Caramell
+  Artist: Caramella Girls
   CoverArtist: Neuro
   Version: 3
   Discnumber: 5


### PR DESCRIPTION
The filename for Disc 5 track 115 was already updated to `Caramella Girls` in a previous commit, but the `Artist` field inside the HJSON still reads `Caramell`.

The karaoke version performed is the **Caramella Girls** sped-up remix, not the original Caramell release — so this PR corrects the internal metadata to match the filename.

Original Caramell: Version https://www.youtube.com/watch?v=H2kdPzjbTkw
Caramella Girls Version: https://www.youtube.com/watch?v=6-8E4Nirh9s

**Change:** `Artist: Caramell` → `Artist: Caramella Girls`

Closes #125 